### PR TITLE
Laravel 10 update + test runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.1, 8.2]
+        laravel: [10.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
 
-    name: Tests P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
-
+    name: Tests P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
     steps:
 
     - name: Checkout
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.composer/cache/files
-        key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+        key: dependencies-php-${{ matrix.php }}-L${{ matrix.laravel }}-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -31,6 +31,12 @@ jobs:
         php-version: ${{ matrix.php }}
         extensions: dom, mbstring, zip
         coverage: none
+
+    - name: Require Laravel Version
+      run: >
+        composer require
+        "laravel/framework:${{ matrix.laravel }}"
+        --no-interaction --no-update
 
     - name: Install Composer dependencies
       run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "laravel/framework": "^9.46.0",
+        "laravel/framework": "10.*|^9.46.0",
         "openai-php/client": "^0.3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "laravel/framework": "10.*|^9.46.0",
+        "laravel/framework": "^9.46.0|^10.0",
         "openai-php/client": "^0.3.0"
     },
     "require-dev": {


### PR DESCRIPTION
# Changes

* Opens up the use of Laravel 10 for the package. 🎉 
* Adds Laravel to the test matrix so both Laravel 9 and 10 can be tested within the matrix.
* Updates the test Github action to use the dependency level (it should be there, I think?) and Laravel version in the cache key.

# Why

It would be awesome to start allowing Laravel 10 apps to the OpenAI package now. I like to build a lot of experiments with the latest version of Laravel, and it only took 5 minutes to make the PR.