### PR TITLE
add testing ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,62 @@ echo $result['choices'][0]['text']; // an open-source, widely-used, server-side 
 
 For usage examples, take a look at the [openai-php/client](https://github.com/openai-php/client) repository.
 
+## Testing
+
+The `OpenAI` facade comes with a `fake()` method that allows you to fake the API responses.
+
+The fake responses are returned in the order they are provided to the `fake()` method.
+
+All responses are having a `fake()` method that allows you to easily create a response object by only providing the parameters relevant for your test case.
+
+```php
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Responses\Completions\CreateResponse;
+
+OpenAI::fake([
+    CreateResponse::fake([
+        'choices' => [
+            [
+                'text' => 'awesome!',
+            ],
+        ],
+    ]),
+]);
+
+$completion = OpenAI::completions()->create([
+    'model' => 'text-davinci-003',
+    'prompt' => 'PHP is ',
+]);
+
+expect($completion['choices'][0]['text'])->toBe('awesome!');
+```
+
+After the requests have been sent there are various methods to ensure that the expected requests were sent:
+
+```php
+// assert completion create request was sent
+OpenAI::assertSent(Completions::class, function (string $method, array $parameters): bool {
+    return $method === 'create' &&
+        $parameters['model'] === 'text-davinci-003' &&
+        $parameters['prompt'] === 'PHP is ';
+});
+// or
+OpenAI::completions()->assertSent(function (string $method, array $parameters): bool {
+    // ...
+});
+
+// assert 2 completion create requests were sent
+OpenAI::assertSent(Completions::class, 2);
+
+// assert no completion create requests were sent
+OpenAI::assertNotSent(Completions::class);
+// or
+OpenAI::completions()->assertNotSent();
+
+// assert no requests were sent
+OpenAI::assertNothingSent();
+```
+
 ---
 
 OpenAI PHP for Laravel is an open-sourced software licensed under the **[MIT license](https://opensource.org/licenses/MIT)**.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.1.0",
         "laravel/framework": "^9.46.0|^10.2.0",
-        "openai-php/client": "^0.3.4"
+        "openai-php/client": "dev-add-testing-ability"
     },
     "require-dev": {
         "laravel/pint": "^1.6",

--- a/src/Facades/OpenAI.php
+++ b/src/Facades/OpenAI.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OpenAI\Laravel\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use OpenAI\Contracts\Response;
+use OpenAI\Laravel\Testing\OpenAIFake;
 
 /**
  * @method static \OpenAI\Resources\Audio audio()
@@ -26,5 +28,16 @@ final class OpenAI extends Facade
     protected static function getFacadeAccessor(): string
     {
         return 'openai';
+    }
+
+    /**
+     * @param  array<array-key, Response>  $responses
+     */
+    public static function fake(array $responses = []): OpenAIFake /** @phpstan-ignore-line */
+    {
+        $fake = new OpenAIFake($responses);
+        static::swap($fake);
+
+        return $fake;
     }
 }

--- a/src/Testing/OpenAIFake.php
+++ b/src/Testing/OpenAIFake.php
@@ -2,9 +2,8 @@
 
 namespace OpenAI\Laravel\Testing;
 
-use Illuminate\Support\Testing\Fakes\Fake;
 use OpenAI\Testing\ClientFake;
 
-class OpenAIFake extends ClientFake implements Fake
+class OpenAIFake extends ClientFake
 {
 }

--- a/src/Testing/OpenAIFake.php
+++ b/src/Testing/OpenAIFake.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace OpenAI\Laravel\Testing;
+
+use Illuminate\Support\Testing\Fakes\Fake;
+use OpenAI\Testing\ClientFake;
+
+class OpenAIFake extends ClientFake implements Fake
+{
+}

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -8,6 +8,8 @@ test('facades')
     ->expect('OpenAI\Laravel\Facades\OpenAI')
     ->toOnlyUse([
         'Illuminate\Support\Facades\Facade',
+        'OpenAI\Contracts\Response',
+        'OpenAI\Laravel\Testing\OpenAIFake',
     ]);
 
 test('service providers')

--- a/tests/Facades/OpenAI.php
+++ b/tests/Facades/OpenAI.php
@@ -100,7 +100,7 @@ test('fake can assert a request was sent', function () {
         'prompt' => 'PHP is ',
     ]);
 
-    OpenAI::assertSent(Completions::class, function ($method, $parameters) {
+    OpenAI::assertSent(Completions::class, function (string $method, array $parameters): bool {
         return $method === 'create' &&
             $parameters['model'] === 'text-davinci-003' &&
             $parameters['prompt'] === 'PHP is ';
@@ -112,7 +112,7 @@ test('fake throws an exception if a request was not sent', function () {
         CreateResponse::fake(),
     ]);
 
-    OpenAI::assertSent(Completions::class, function ($method, $parameters) {
+    OpenAI::assertSent(Completions::class, function (string $method, array $parameters): bool {
         return $method === 'create' &&
             $parameters['model'] === 'text-davinci-003' &&
             $parameters['prompt'] === 'PHP is ';
@@ -129,7 +129,7 @@ test('fake can assert a request was sent on the resource', function () {
         'prompt' => 'PHP is ',
     ]);
 
-    OpenAI::completions()->assertSent(function ($method, $parameters) {
+    OpenAI::completions()->assertSent(function (string $method, array $parameters): bool {
         return $method === 'create' &&
             $parameters['model'] === 'text-davinci-003' &&
             $parameters['prompt'] === 'PHP is ';

--- a/tests/Facades/OpenAI.php
+++ b/tests/Facades/OpenAI.php
@@ -60,7 +60,7 @@ test('fake throws an exception if there is no more given response', function () 
     ]);
 })->expectExceptionMessage('No fake responses left');
 
-test('calling fake twice does not override the instance instead it appends the new responses', function () {
+test('append more fake responses', function () {
     OpenAI::fake([
         CreateResponse::fake([
             'id' => 'cmpl-1',

--- a/tests/Facades/OpenAI.php
+++ b/tests/Facades/OpenAI.php
@@ -4,6 +4,8 @@ use Illuminate\Config\Repository;
 use OpenAI\Laravel\Facades\OpenAI;
 use OpenAI\Laravel\ServiceProvider;
 use OpenAI\Resources\Completions;
+use OpenAI\Responses\Completions\CreateResponse;
+use PHPUnit\Framework\ExpectationFailedException;
 
 it('resolves resources', function () {
     $app = app();
@@ -22,3 +24,193 @@ it('resolves resources', function () {
 
     expect($completions)->toBeInstanceOf(Completions::class);
 });
+
+test('fake returns the given response', function () {
+    OpenAI::fake([
+        CreateResponse::fake([
+            'choices' => [
+                [
+                    'text' => 'awesome!',
+                ],
+            ],
+        ]),
+    ]);
+
+    $completion = OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    expect($completion['choices'][0]['text'])->toBe('awesome!');
+});
+
+test('fake throws an exception if there is no more given response', function () {
+    OpenAI::fake([
+        CreateResponse::fake(),
+    ]);
+
+    OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+})->expectExceptionMessage('No fake responses left');
+
+test('calling fake twice does not override the instance instead it appends the new responses', function () {
+    OpenAI::fake([
+        CreateResponse::fake([
+            'id' => 'cmpl-1',
+        ]),
+    ]);
+
+    OpenAI::addResponses([
+        CreateResponse::fake([
+            'id' => 'cmpl-2',
+        ]),
+    ]);
+
+    $completion = OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    expect($completion)
+        ->id->toBe('cmpl-1');
+
+    $completion = OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    expect($completion)
+        ->id->toBe('cmpl-2');
+});
+
+test('fake can assert a request was sent', function () {
+    OpenAI::fake([
+        CreateResponse::fake(),
+    ]);
+
+    OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    OpenAI::assertSent(Completions::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-davinci-003' &&
+            $parameters['prompt'] === 'PHP is ';
+    });
+});
+
+test('fake throws an exception if a request was not sent', function () {
+    OpenAI::fake([
+        CreateResponse::fake(),
+    ]);
+
+    OpenAI::assertSent(Completions::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-davinci-003' &&
+            $parameters['prompt'] === 'PHP is ';
+    });
+})->expectException(ExpectationFailedException::class);
+
+test('fake can assert a request was sent on the resource', function () {
+    OpenAI::fake([
+        CreateResponse::fake(),
+    ]);
+
+    OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    OpenAI::completions()->assertSent(function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-davinci-003' &&
+            $parameters['prompt'] === 'PHP is ';
+    });
+});
+
+test('fake can assert a request was sent n times', function () {
+    OpenAI::fake([
+        CreateResponse::fake(),
+        CreateResponse::fake(),
+    ]);
+
+    OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    OpenAI::assertSent(Completions::class, 2);
+});
+
+test('fake throws an exception if a request was not sent n times', function () {
+    OpenAI::fake([
+        CreateResponse::fake(),
+        CreateResponse::fake(),
+    ]);
+
+    OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    OpenAI::assertSent(Completions::class, 2);
+})->expectException(ExpectationFailedException::class);
+
+test('fake can assert a request was not sent', function () {
+    OpenAI::fake();
+
+    OpenAI::assertNotSent(Completions::class);
+});
+
+test('fake throws an exception if a unexpected request was sent', function () {
+    OpenAI::fake([
+        CreateResponse::fake(),
+    ]);
+
+    OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    OpenAI::assertNotSent(Completions::class);
+})->expectException(ExpectationFailedException::class);
+
+test('fake can assert a request was not sent on the resource', function () {
+    OpenAI::fake([
+        CreateResponse::fake(),
+    ]);
+
+    OpenAI::completions()->assertNotSent();
+});
+
+test('fake can assert no request was sent', function () {
+    OpenAI::fake();
+
+    OpenAI::assertNothingSent();
+});
+
+test('fake throws an exception if any request was sent when non was expected', function () {
+    OpenAI::fake([
+        CreateResponse::fake(),
+    ]);
+
+    OpenAI::completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    OpenAI::assertNothingSent();
+})->expectException(ExpectationFailedException::class);


### PR DESCRIPTION
Implements https://github.com/openai-php/laravel/issues/23

As I've mentioned here, most of the logic is in the client: https://github.com/openai-php/client/pull/71

Todos:
- [x] add documentation