### PR TITLE
only run publishes() when app is running in console

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -38,9 +38,11 @@ final class ServiceProvider extends BaseServiceProvider
      */
     public function boot(): void
     {
-        $this->publishes([
-            __DIR__.'/../config/openai.php' => config_path('openai.php'),
-        ]);
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/openai.php' => config_path('openai.php'),
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
Avoid unnecessary calls to `ServiceProvider@publishes()` if app is not running in the console