### PR TITLE
Make ServiceProvider deferred

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,7 +13,7 @@ use OpenAI\Laravel\Exceptions\ApiKeyIsMissing;
 /**
  * @internal
  */
-class ServiceProvider extends BaseServiceProvider implements DeferrableProvider
+final class ServiceProvider extends BaseServiceProvider implements DeferrableProvider
 {
     /**
      * Register any application services.

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenAI\Laravel;
 
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use OpenAI;
 use OpenAI\Client;
@@ -12,7 +13,7 @@ use OpenAI\Laravel\Exceptions\ApiKeyIsMissing;
 /**
  * @internal
  */
-final class ServiceProvider extends BaseServiceProvider
+class ServiceProvider extends BaseServiceProvider implements DeferrableProvider
 {
     /**
      * Register any application services.

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -16,6 +16,7 @@ test('service providers')
         'Illuminate\Support\ServiceProvider',
         'OpenAI\Laravel',
         'OpenAI',
+        'Illuminate\Contracts\Support\DeferrableProvider',
 
         // helpers...
         'config',


### PR DESCRIPTION
Since ServiceProvider has a `provides()` function, I'm assuming it was intended to implement DeferrableServiceProvider.

I also think that the `final` keyword should be dropped. I don't see a benefit to making it harder to extend the ServiceProvider if I only need to tweak how I'm handling the `register()` method (for instance).