### PR TITLE
add timeout configuration support

### DIFF
--- a/config/openai.php
+++ b/config/openai.php
@@ -15,4 +15,14 @@ return [
     'api_key' => env('OPENAI_API_KEY'),
     'organization' => env('OPENAI_ORGANIZATION'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Request Timeout
+    |--------------------------------------------------------------------------
+    |
+    | The timeout may be used to specify the maximum number of seconds to wait
+    | for a response. By default, the client will time out after 30 seconds.
+    */
+
+    'request_timeout' => env('OPENAI_REQUEST_TIMEOUT', 30),
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -29,7 +29,11 @@ final class ServiceProvider extends BaseServiceProvider implements DeferrablePro
                 throw ApiKeyIsMissing::create();
             }
 
-            return OpenAI::client($apiKey, $organization);
+            return OpenAI::factory()
+                ->withApiKey($apiKey)
+                ->withOrganization($organization)
+                ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('openai.request_timeout', 30)]))
+                ->make();
         });
 
         $this->app->alias(ClientContract::class, 'openai');

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -16,6 +16,7 @@ test('facades')
 test('service providers')
     ->expect('OpenAI\Laravel\ServiceProvider')
     ->toOnlyUse([
+        'GuzzleHttp\Client',
         'Illuminate\Support\ServiceProvider',
         'OpenAI\Laravel',
         'OpenAI',


### PR DESCRIPTION
This PR allows to configure the HTTP timeout via the `openai.php` configuration file.

```php
    'request_timeout' => env('OPENAI_REQUEST_TIMEOUT', 30),
```