### PR TITLE
Readme: Fix model used in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Finally, you may use the `OpenAI` facade to access the OpenAI API:
 use OpenAI\Laravel\Facades\OpenAI;
 
 $result = OpenAI::chat()->create([
-    'model' => 'gpt-3.5-turbo-instruct',
+    'model' => 'gpt-3.5-turbo',
     'messages' => [
         ['role' => 'user', 'content' => 'Hello!'],
     ],


### PR DESCRIPTION
https://github.com/openai-php/laravel/pull/65 and https://github.com/openai-php/laravel/pull/56 collided a bit and incorrect model is displayed in Readme example (instruct is a completion endpoint model, not chat. OpenAI getting started docs use gpt-3.5-turbo)