### PR TITLE
Add OpenAI factory service

### DIFF
--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -18,6 +18,7 @@ test('service providers')
     ->toOnlyUse([
         'GuzzleHttp\Client',
         'Illuminate\Support\ServiceProvider',
+        'Illuminate\Container\Container',
         'OpenAI\Laravel',
         'OpenAI',
         'Illuminate\Contracts\Support\DeferrableProvider',

--- a/tests/ServiceProvider.php
+++ b/tests/ServiceProvider.php
@@ -3,8 +3,23 @@
 use Illuminate\Config\Repository;
 use OpenAI\Client;
 use OpenAI\Contracts\ClientContract;
+use OpenAI\Factory;
 use OpenAI\Laravel\Exceptions\ApiKeyIsMissing;
 use OpenAI\Laravel\ServiceProvider;
+
+it('binds the factory on the container', function () {
+    $app = app();
+
+    $app->bind('config', fn () => new Repository([
+        'openai' => [
+            'api_key' => 'test',
+        ],
+    ]));
+
+    (new ServiceProvider($app))->register();
+
+    expect($app->get(Factory::class))->toBeInstanceOf(Factory::class);
+});
 
 it('binds the client on the container', function () {
     $app = app();
@@ -55,6 +70,8 @@ it('provides', function () {
     expect($provides)->toBe([
         Client::class,
         ClientContract::class,
+        Factory::class,
         'openai',
+        'openai.factory',
     ]);
 });


### PR DESCRIPTION
**Summary: This PR adds support for adding a custom OpenAI factory implementation by binding `OpenAI\Factory`.**

While the Factory class itself is final, binding it to a service still has the benefit of letting users customize client bootstrapping by decorating or downright replacing the factory call with their own.

As a concrete example: Right now, [OpenAI added _projects_ to their API](https://help.openai.com/en/articles/9186755-managing-your-work-in-the-api-platform-with-projects) that require setting a specific header. The OpenAI factory from the `openai-php/client` package provides a `withProject()` method; this change is yet unreleased, however.  
In the mean time, there's not a lot users can do, other than to wait or override the client binding. That is despite the client factory actually providing a lot of convenience helpers to add custom parameters to the instance: The service provider just doesn't expose them.  

This PR changes that and binds the Factory to the container. This way, applications can [decorate](https://laravel.com/docs/11.x/container#extending-bindings) the factory, like so:
```php
$this->app->extend(OpenAI\Factory::class, fn(OpenAI\Factory $factory) => $factory
    ->withHttpHeader('OpenAI-Project', config('openai.project'))
);
```

...and be done with it for the time being. Of course, this also allows all other kinds of possibly required customization.  

I would expect this to ease the maintenance burden on the contributors a bit, since OpenAI's changes to their API don't have to be reflected immediately without users complaining.