### PR TITLE
Moving laravel framework to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "require": {
         "php": "^8.1.0",
         "guzzlehttp/guzzle": "^7.8.1",
-        "laravel/framework": "^9.46.0|^10.34.2|^11.0",
         "openai-php/client": "^v0.10.1"
     },
     "require-dev": {
+        "laravel/framework": "^9.46.0|^10.34.2|^11.0",
         "laravel/pint": "^1.13.6",
         "pestphp/pest": "^2.27.0",
         "pestphp/pest-plugin-arch": "^2.4.1",


### PR DESCRIPTION
Related to discussions

https://github.com/openai-php/laravel/issues/40
https://github.com/openai-php/laravel/issues/34

I had the a similar issue when trying to add the package to a laravel-zero application (conflict with Illuminate packages). 

Moving to require-dev should allow the same development experience while not forcing a full install of the laravel framework when adding to a laravel-zero project.