### PR TITLE
Adds PR template per contributing guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
+- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
 -->
 
 ### What:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
+-->
+
+### What:
+
+- [ ] Bug Fix
+- [ ] New Feature
+- [ ] Docs
+
+### Description:
+
+<!-- describe what your PR is solving -->
+
+### Related:
+
+<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Docs

### Description:

The `CONTRIBUTING.md` file links to the PR template that isn't there. This adds the one used from PEST and I added a `docs` line as well.