### PR TITLE
feature: Use PSR-18 compatible wrapper for Laravel HTTP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": "^8.1.0",
         "guzzlehttp/guzzle": "^7.9.2",
         "laravel/framework": "^9.46.0|^10.34.2|^11.29.0",
-        "openai-php/client": "^0.10.2"
+        "openai-php/client": "^0.10.2",
+        "swisnl/laravel-psr-http-client-bridge": "^0.2.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18.1",

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Laravel;
 
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use OpenAI;
 use OpenAI\Client;
@@ -34,7 +35,8 @@ final class ServiceProvider extends BaseServiceProvider implements DeferrablePro
                 ->withApiKey($apiKey)
                 ->withOrganization($organization)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('openai.request_timeout', 30)]))
+                ->withHttpClient(new \Swis\Laravel\Bridge\PsrHttpClient\Client(
+                    fn () => Http::timeout((int) config('openai.request_timeout', 30))))
                 ->make();
         });
 


### PR DESCRIPTION
I was trying to review OpenAI requests using Telescope which captures requests made using the Laravel HTTP Client, however this integration uses Guzzle directly.

The OpenAI PHP library supports any PSR-18 compatible client, so I pulled in `swisnl/laravel-psr-http-client-bridge` which is a PSR-18 compatible wrapper around the Laravel HTTP Client and used that instead of Guzzle directly.

This change allows the requests to show up in Telescope as expected.