### PR TITLE
feat: add base URI configuration with OPENAI_BASE_URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ for a response. By default, the client will time out after 30 seconds.
 OPENAI_REQUEST_TIMEOUT=
 ```
 
+### Base URI
+
+The base URI may be used to specify the base URI of the OpenAI API.
+By default, the client will use the OpenAI API base URI.
+
+```env
+OPENAI_BASE_URI=
+```
+
 ## Usage
 
 For usage examples, take a look at the [openai-php/client](https://github.com/openai-php/client) repository.

--- a/config/openai.php
+++ b/config/openai.php
@@ -25,4 +25,16 @@ return [
     */
 
     'request_timeout' => env('OPENAI_REQUEST_TIMEOUT', 30),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Base URI
+    |--------------------------------------------------------------------------
+    |
+    | The base URI is the root URL that the client will use to make requests.
+    | By default, the client will use the OpenAI API base URI.
+    | The schema can be specified (http or https).
+    | e.g.: http://localhost:11434/v1 for a local Ollama instance.
+    */
+    'base_uri' => env('OPENAI_BASE_URI', 'api.openai.com/v1'),
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -35,6 +35,7 @@ final class ServiceProvider extends BaseServiceProvider implements DeferrablePro
                 ->withOrganization($organization)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
                 ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('openai.request_timeout', 30)]))
+                ->withBaseUri(config('openai.base_uri'))
                 ->make();
         });
 


### PR DESCRIPTION
I was able to use Ollama locally (and its [OpenAI compatible API](https://github.com/ollama/ollama/blob/main/docs/openai.md)) with this change + https://github.com/openai-php/client/pull/375.