### PR TITLE
Fix for exceptions on install if .env files are missing

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -78,6 +78,10 @@ class InstallCommand extends Command
 
     private function addEnvKeys(string $envFile): void
     {
+        if (! is_writable(base_path($envFile)) {
+            return;
+        }
+            
         $fileContent = file_get_contents(base_path($envFile));
 
         if ($fileContent === false) {


### PR DESCRIPTION
It's common to use env.{environment-name} and when that's the case, the installer throws exceptions which this resolves.

Fixes #120