### PR TITLE
Update Open AI API link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 ------
-**OpenAI PHP** for Laravel is a community-maintained PHP API client that allows you to interact with the [Open AI API](https://beta.openai.com/docs/api-reference/introduction). If you or your business relies on this package, it's important to support the developers who have contributed their time and effort to create and maintain this valuable tool:
+**OpenAI PHP** for Laravel is a community-maintained PHP API client that allows you to interact with the [Open AI API](https://platform.openai.com/docs/api-reference/introduction). If you or your business relies on this package, it's important to support the developers who have contributed their time and effort to create and maintain this valuable tool:
 
 - Nuno Maduro: **[github.com/sponsors/nunomaduro](https://github.com/sponsors/nunomaduro)**
 - Sandro Gehri: **[github.com/sponsors/gehrisandro](https://github.com/sponsors/gehrisandro)**


### PR DESCRIPTION
Changed the Open AI API URL from https://beta.openai.com/docs/api-reference/introduction to https://platform.openai.com/docs/api-reference/introduction