### PR TITLE
Adds ability to configure Project & Base URL via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ OPENAI_API_KEY=sk-...
 OPENAI_ORGANIZATION=org-...
 ```
 
+Optionally, you can also specify an OpenAI Project ID:
+
+```env
+OPENAI_PROJECT=proj_...
+```
+
 Finally, you may use the `OpenAI` facade to access the OpenAI API:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -41,12 +41,6 @@ OPENAI_API_KEY=sk-...
 OPENAI_ORGANIZATION=org-...
 ```
 
-Optionally, you can also specify an OpenAI Project ID:
-
-```env
-OPENAI_PROJECT=proj_...
-```
-
 Finally, you may use the `OpenAI` facade to access the OpenAI API:
 
 ```php
@@ -75,6 +69,23 @@ and organization on your OpenAI dashboard, at https://openai.com.
 ```env
 OPENAI_API_KEY=
 OPENAI_ORGANIZATION=
+```
+
+### OpenAI Project
+
+For implementations that require a project ID, you can specify 
+the OpenAI project ID in your environment variables.
+
+```env
+OPENAI_PROJECT=proj_...
+```
+
+### OpenAI API Base URL
+
+The base URL for the OpenAI API. By default, this is set to `api.openai.com/v1`.
+
+```env
+OPENAI_BASE_URL=
 ```
 
 ### Request Timeout

--- a/config/openai.php
+++ b/config/openai.php
@@ -14,7 +14,27 @@ return [
 
     'api_key' => env('OPENAI_API_KEY'),
     'organization' => env('OPENAI_ORGANIZATION'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | OpenAI API Project
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify your OpenAI API project. This is used optionally in
+    | situations where you are using a legacy user API key and need association
+    | with a project. THis is not required for the newer API keys.
+    */
     'project' => env('OPENAI_PROJECT'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | OpenAI Base URL
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify your OpenAI API base URL used to make requests. This
+    | is needed if using a custom API endpoint. Defaults to: api.openai.com/v1
+    */
+    'base_uri' => env('OPENAI_BASE_URL'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/openai.php
+++ b/config/openai.php
@@ -22,7 +22,7 @@ return [
     |
     | Here you may specify your OpenAI API project. This is used optionally in
     | situations where you are using a legacy user API key and need association
-    | with a project. THis is not required for the newer API keys.
+    | with a project. This is not required for the newer API keys.
     */
     'project' => env('OPENAI_PROJECT'),
 

--- a/config/openai.php
+++ b/config/openai.php
@@ -14,6 +14,7 @@ return [
 
     'api_key' => env('OPENAI_API_KEY'),
     'organization' => env('OPENAI_ORGANIZATION'),
+    'project' => env('OPENAI_PROJECT'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -78,6 +78,15 @@ class InstallCommand extends Command
 
     private function addEnvKeys(string $envFile): void
     {
+        if (! is_writable(base_path($envFile))) {
+            View::render('components.two-column-detail', [
+                'left' => $envFile,
+                'right' => 'File is not writable.',
+            ]);
+
+            return;
+        }
+
         $fileContent = file_get_contents(base_path($envFile));
 
         if ($fileContent === false) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,6 +25,7 @@ final class ServiceProvider extends BaseServiceProvider implements DeferrablePro
         $this->app->singleton(ClientContract::class, static function (): Client {
             $apiKey = config('openai.api_key');
             $organization = config('openai.organization');
+            $project = config('openai.project');
 
             if (! is_string($apiKey) || ($organization !== null && ! is_string($organization))) {
                 throw ApiKeyIsMissing::create();
@@ -33,6 +34,7 @@ final class ServiceProvider extends BaseServiceProvider implements DeferrablePro
             return OpenAI::factory()
                 ->withApiKey($apiKey)
                 ->withOrganization($organization)
+                ->withProject($project)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
                 ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('openai.request_timeout', 30)]))
                 ->make();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,18 +26,27 @@ final class ServiceProvider extends BaseServiceProvider implements DeferrablePro
             $apiKey = config('openai.api_key');
             $organization = config('openai.organization');
             $project = config('openai.project');
+            $baseUri = config('openai.base_uri');
 
             if (! is_string($apiKey) || ($organization !== null && ! is_string($organization))) {
                 throw ApiKeyIsMissing::create();
             }
 
-            return OpenAI::factory()
+            $client = OpenAI::factory()
                 ->withApiKey($apiKey)
                 ->withOrganization($organization)
-                ->withProject($project)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('openai.request_timeout', 30)]))
-                ->make();
+                ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('openai.request_timeout', 30)]));
+
+            if (is_string($project)) {
+                $client->withProject($project);
+            }
+
+            if (is_string($baseUri)) {
+                $client->withBaseUri($baseUri);
+            }
+
+            return $client->make();
         });
 
         $this->app->alias(ClientContract::class, 'openai');


### PR DESCRIPTION
* This enables Project to be configured in `.env` and loaded in, optional.
* This enables Base URL to be configured optionally in `.env`
* Corrects a crash when you try and write files to an env (`.env` or `.env.example`) when they don't exist.

---

fixes: #101, fixes: #135, fixes: #105