### PR TITLE
build: restore Laravel 11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [12]
+        laravel: [11, 12]
         pest: [3, 4]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.2.0",
         "guzzlehttp/guzzle": "^7.9.3",
-        "laravel/framework": "^12.12",
+        "laravel/framework": "^11.29|^12.12",
         "openai-php/client": "^0.12.0"
     },
     "require-dev": {


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature
- [ ] Docs

### Description:

We dropped Laravel 11 support, but since Laravel 12 had no breaking changes. We can keep Laravel 11 around for a bit longer.

