### PR TITLE
docs: add vision example using image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,35 @@ $result = OpenAI::chat()->create([
 
 echo $result->choices[0]->message->content; // Hello! How can I assist you today?
 ```
+## Vision: Image Understanding with OpenAI
+
+With an image URL: You can use 'OpenAI' to understand and describe images by providing an image URL along with a prompt. Here's how to send a message that includes both text and an image using the OpenAI Laravel SDK:
+
+```php
+use OpenAI\Laravel\Facades\OpenAI;
+
+    // Define the prompt you want to send along with the image
+    $prompt = "What is in this image?";
+
+    // Provide accessible image URL
+    $img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/1599px-2023_06_08_Raccoon1.jpg";
+
+    $response = OpenAI::chat()->create([
+        'model' => 'gpt-4o',
+        'messages' => [
+            [
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => $prompt],
+                    ['type' => 'image_url', 'image_url' => ['url' => $img_url]],
+                ],
+            ],
+        ],
+    ]);
+
+    // Output the model's description of the image
+    echo $response->choices[0]->message->content; // "The image features a raccoon peeking"
+```
 
 ## Configuration
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Docs

### Description:
This pull request adds a new usage example to the README demonstrating how to use the OpenAI Laravel SDK to understand and describe images using GPT-4o and an accessible image URL.
<!-- describe what your PR is solving -->

###  Example Included

The example shows how to:
- Provide both a text prompt and an image URL
- Output GPT-4o's vision capabilities in a Laravel-friendly way

###  Why It's Useful
- Showcases advanced GPT-4o usage directly in Laravel
- Makes it easy for developers to test image understanding via chat
- Builds on the existing text-only examples by adding multimodal support

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
