### PR TITLE
Update README.md: use chat() instead of responses()

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Finally, you may use the `OpenAI` facade to access the OpenAI API:
 ```php
 use OpenAI\Laravel\Facades\OpenAI;
 
-$response = OpenAI::responses()->create([
+$response = OpenAI::chat()->create([
     'model' => 'gpt-5',
     'input' => 'Hello!',
 ]);


### PR DESCRIPTION
The responses() method has been updated to chat() since responses() is not available in this package.

<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Docs

### Description:

<!-- describe what your PR is solving -->

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
