### PR TITLE
feat(http): add GuzzleHttp middleware to dispatch Laravel HTTP events

### DIFF
--- a/src/Http/Adapters/GuzzleHttpAdapter.php
+++ b/src/Http/Adapters/GuzzleHttpAdapter.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace OpenAI\Laravel\Http\Adapters;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Events\ConnectionFailed;
+use Illuminate\Http\Client\Events\RequestSending;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Event;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @internal
+ *
+ * This class hooks into GuzzleHttp's middleware and fires
+ * Laravel's HTTP client events.
+ */
+class GuzzleHttpAdapter
+{
+    /**
+     * Create a new GuzzleHttp client instance that dispatches Laravel HTTP events.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function client(array $options = [], ?callable $handler = null): Client
+    {
+        $stack = HandlerStack::create($handler);
+
+        // Push middleware that hooks into Guzzle’s request lifecycle
+        $stack->push(Middleware::tap(
+            // Before sending the request → dispatch "sending" event
+            function (RequestInterface $request) {
+                event(new RequestSending(new Request($request)));
+
+                return $request;
+            },
+
+            // After sending → handle promise (success or failure)
+            function (RequestInterface $request, array $_opt, PromiseInterface $promise) {
+                return $promise
+                    ->then(function (ResponseInterface $response) use ($request) {
+                        // Dispatch "response received" event
+                        Event::dispatch(new ResponseReceived(
+                            new Request($request),
+                            new Response($response)
+                        ));
+
+                        return $response;
+                    })
+                    ->otherwise(function ($reason) use ($request) {
+                        // Normalize the failure into a Laravel ConnectionException
+                        $exception = $reason instanceof RequestException
+                            ? new ConnectionException($reason->getMessage(), $reason->getCode(), $reason)
+                            : new ConnectionException(
+                                new RequestException('Connection failed', $request)
+                            );
+
+                        // Dispatch "connection failed" event
+                        Event::dispatch(new ConnectionFailed(new Request($request), $exception));
+
+                        // Re-throw the original rejection
+                        return \GuzzleHttp\Promise\Create::rejectionFor($reason);
+                    });
+            }
+        ));
+
+        return new Client(array_merge($options, ['handler' => $stack]));
+    }
+
+    /**
+     * Create a GuzzleHttp with optional options and handler stack.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public static function make(array $options = [], ?callable $stack = null): Client
+    {
+        return (new self)->client($options, $stack);
+    }
+
+    /**
+     * Create GuzzleHttp with specify the timeout (in seconds) for the client.
+     */
+    public static function timeout(mixed $seconds): Client
+    {
+        return static::make(['timeout' => $seconds]);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,6 +11,7 @@ use OpenAI\Client;
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Laravel\Commands\InstallCommand;
 use OpenAI\Laravel\Exceptions\ApiKeyIsMissing;
+use OpenAI\Laravel\Http\Adapters\GuzzleHttpAdapter;
 
 /**
  * @internal
@@ -36,7 +37,7 @@ final class ServiceProvider extends BaseServiceProvider implements DeferrablePro
                 ->withApiKey($apiKey)
                 ->withOrganization($organization)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('openai.request_timeout', 30)]));
+                ->withHttpClient(GuzzleHttpAdapter::timeout(config('openai.request_timeout', 30)));
 
             if (is_string($project)) {
                 $client->withProject($project);

--- a/tests/Http/GuzzleHttpAdapterTest.php
+++ b/tests/Http/GuzzleHttpAdapterTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Events\Dispatcher;
+use OpenAI\Laravel\Http\Adapters\GuzzleHttpAdapter;
+
+beforeEach(function () {
+    app()->instance(DispatcherContract::class, new Dispatcher(app()));
+    app()->alias(DispatcherContract::class, 'events'); // Important
+});
+
+it('create GuzzleHttp client instance', function () {
+    expect((new GuzzleHttpAdapter)->make())->toBeInstanceOf(GuzzleHttp\Client::class);
+    expect((new GuzzleHttpAdapter)->client())->toBeInstanceOf(GuzzleHttp\Client::class);
+    expect((new GuzzleHttpAdapter)->timeout(3))->toBeInstanceOf(GuzzleHttp\Client::class);
+});
+
+it('create GuzzleHttp client instance with options timeout and handler', function () {
+    $timeout = 0;
+    $handler = HandlerStack::create(new MockHandler([new GuzzleResponse(200, [], 'OK')]));
+    $handler->push(Middleware::tap(
+        after: function ($req, array $options) use (&$timeout) {
+            $timeout = $options['timeout'];
+            expect($options['handler'])->toBeInstanceOf(HandlerStack::class);
+        }
+    ));
+    $client = GuzzleHttpAdapter::make(['timeout' => 3], $handler);
+    $response = $client->request('GET', 'https://example.com');
+
+    expect($client)->toBeInstanceOf(\GuzzleHttp\Client::class);
+    expect($response)->toBeInstanceOf(\Psr\Http\Message\ResponseInterface::class);
+    expect($response->getBody()->getContents())->toBe('OK');
+    expect($response->getStatusCode())->toBe(200);
+    expect($timeout)->toBe(3);
+});
+
+it('runs middleware before and after callbacks to callable events', function () {
+    $calledBefore = false;
+    $calledAfter = false;
+
+    $mock = new MockHandler([new GuzzleResponse(200, [], 'OK')]);
+    $stack = HandlerStack::create($mock);
+
+    $stack->push(Middleware::tap(
+        before: function () use (&$calledBefore) {
+            $calledBefore = true;
+        },
+        after: function ($req, array $options, $promise) use (&$calledAfter) {
+            $calledAfter = true;
+        }
+    ));
+
+    $client = (new GuzzleHttpAdapter)->client([], $stack);
+
+    $response = $client->request('GET', 'https://example.com');
+
+    // Force the response to complete
+    expect($response->getBody()->getContents())->toBe('OK');
+    expect($calledBefore)->toBeTrue();
+    expect($calledAfter)->toBeTrue();
+    expect($response->getStatusCode())->toBe(200);
+});
+
+it('handles rejected promise without Laravel events', function () {
+
+    $mock = new MockHandler([new RequestException('Error', new GuzzleRequest('GET', 'test'))]);
+    $handler = HandlerStack::create($mock);
+    $client = (new GuzzleHttpAdapter)->client([], $handler);
+
+    $promise = $client->getAsync('https://example.com');
+
+    $rejection = null;
+    $promise->then(null, function ($reason) use (&$rejection) {
+        $rejection = $reason;
+    })->wait();
+
+    expect($rejection)->toBeInstanceOf(RequestException::class);
+});
+
+it('handles rejected promise and normalizes ConnectionException', function () {
+    $calledAfter = false;
+    $reason = null;
+
+    // Mock a rejected promise
+    $request = new GuzzleRequest('GET', 'test');
+    $mock = new MockHandler([new RequestException('Connection failed', $request)]);
+    $stack = HandlerStack::create($mock);
+
+    // Push tap middleware to observe "after"
+    $stack->push(Middleware::tap(
+        after: function ($req, array $o, $promise) use (&$calledAfter, &$reason) {
+            $promise->otherwise(function ($responseReason) use (&$calledAfter, &$reason) {
+                $reason = $responseReason;
+                $calledAfter = true;
+            });
+        }
+    ));
+
+    try {
+        GuzzleHttpAdapter::make([], $stack)->request('GET', 'https://example.com');
+    } catch (\GuzzleHttp\Exception\RequestException $e) {
+        // expected
+    }
+
+    expect($calledAfter)->toBeTrue(); // ensure the "after" handler ran
+    expect($reason)->toBeInstanceOf(RequestException::class);
+});


### PR DESCRIPTION
# ✨ Feature: Guzzle Middleware for Laravel HTTP Events

## Summary
Added a **GuzzleHttp middleware** that dispatches **Laravel HTTP client events** for better integration.

## Benefits
- Dispatches Laravel events `RequestSending`, `ResponseReceived`, and `ConnectionFailed`
- Opens up the ability for users to add their own listeners to log requests and responses
- Third-party packages can automatically capture requests/responses (e.g., **Telescope** and **Pulse**)
- Resolves several open issues and pull requests: #75     #127   #78
- Provides an easy way to add custom handler to modify HTTP request/response

## Changes
- Implemented custom Guzzle middleware using class `GuzzleHttpAdapter`
- Ensured Laravel `Http::` event listeners are triggered properly
- Added **Pest tests** to validate request, response, and middleware behavior

## ✅ Tests
All **Pest tests** passed successfully.

---

**Type:** `feat(http)`
