### PR TITLE
Remove assistants beta header

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -35,7 +35,6 @@ final class ServiceProvider extends BaseServiceProvider implements DeferrablePro
             $client = OpenAI::factory()
                 ->withApiKey($apiKey)
                 ->withOrganization($organization)
-                ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
                 ->withHttpClient(new \GuzzleHttp\Client(['timeout' => config('openai.request_timeout', 30)]));
 
             if (is_string($project)) {


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature
- [ ] Docs

### Description:

The hotfix ensures that the conversations API can be used, as currently its usage is blocked by the mandatory assistants beta header.

### Related:

https://github.com/openai-php/client/pull/688
https://github.com/openai-php/client/pull/658