### PR TITLE
Updated README testing section in Responses assert example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ expect($response->outputText)->toBe('awesome!');
 After the requests have been sent there are various methods to ensure that the expected requests were sent:
 
 ```php
+use OpenAI\Resources\Responses;
+
 // assert completion create request was sent
 OpenAI::assertSent(Responses::class, function (string $method, array $parameters): bool {
     return $method === 'create' &&


### PR DESCRIPTION


### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Docs

### Description:

Updated the README testing section to include the `Responses` class import `use OpenAI\Resources\Responses;`. 
 
This clarifies which class the user should use in assert tests, helping them understand the example quickly.

### Related:

N/A
