### PR TITLE
feat: add Webhook handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,47 @@ OpenAI::assertSent(Responses::class, function (string $method, array $parameters
 
 For more testing examples, take a look at the [openai-php/client](https://github.com/openai-php/client#testing) repository.
 
+## Webhooks
+
+You can easily handle OpenAI webhooks using the built-in webhook receiver. Start by enabling the webhook receiver:
+
+```env
+OPENAI_WEBHOOKS_ENABLED=true
+```
+
+Register the webhook on your OpenAI dashboard, at https://openai.com.
+
+### Webhook Endpoint
+
+By default, the webhook endpoint is configured to `/openai/webhook`. You can customize this URL by changing the `openai.webhook.path` configuration value.
+
+```env
+OPENAI_WEBHOOK_URI=/openai/webhook
+```
+
+### Webhook Signing Secret
+
+Then, add your webhook signing secret to your `.env` file:
+
+```env
+OPENAI_WEBHOOK_SECRET=whsec_...
+```
+
+Now you're ready to handle incoming webhooks. All events received will be dispatched as Laravel events, which you can listen to in your application.
+
+```php
+use OpenAI\Laravel\Events\WebhookReceived;
+use Illuminate\Support\Facades\Event;
+
+Event::listen(WebhookReceived::class, function (WebhookReceived $event) {
+    if ($event->type === WebhookEventType::ResponseCompleted) {
+        $payload = $event->payload;
+        
+        // Handle the completed response...
+    }
+});
+```
+
 ---
 
 OpenAI PHP for Laravel is an open-sourced software licensed under the **[MIT license](https://opensource.org/licenses/MIT)**.

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,12 @@
         "php": "^8.2.0",
         "guzzlehttp/guzzle": "^7.9.3",
         "laravel/framework": "^11.29|^12.12",
-        "openai-php/client": "^0.18.0"
+        "openai-php/client": "dev-main",
+        "symfony/psr-http-message-bridge": "^8.0.0"
     },
     "require-dev": {
         "laravel/pint": "^1.22.0",
+        "orchestra/testbench": "^10.8.0",
         "pestphp/pest": "^3.8.2|^4.0.0",
         "pestphp/pest-plugin-arch": "^3.1.1|^4.0.0",
         "phpstan/phpstan": "^2.1",

--- a/config/openai.php
+++ b/config/openai.php
@@ -46,4 +46,38 @@ return [
     */
 
     'request_timeout' => env('OPENAI_REQUEST_TIMEOUT', 30),
+
+    'webhook' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Webhook
+        |--------------------------------------------------------------------------
+        | This option controls whether the OpenAI webhook endpoint is
+        | enabled. Set this to true to enable automatic handling of webhook
+        | requests from OpenAI.
+        */
+        'enabled' => env('OPENAI_WEBHOOK_ENABLED', false),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Webhook URI
+        |--------------------------------------------------------------------------
+        |
+        | This value is the URI path where OpenAI will send webhook requests to.
+        | You may change this path to anything you like. Make sure to update
+        | your OpenAI webhook settings to match this URI.
+        */
+        'uri' => env('OPENAI_WEBHOOK_URI', '/openai/webhook'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Webhook Signing secret
+        |--------------------------------------------------------------------------
+        |
+        | This value is the signing secret used to verify incoming webhook
+        | requests from OpenAI. You can find this secret in your OpenAI
+        | dashboard, in the webhook settings for your application.
+        */
+        'secret' => env('OPENAI_WEBHOOK_SECRET'),
+    ],
 ];

--- a/config/openai.php
+++ b/config/openai.php
@@ -60,14 +60,26 @@ return [
 
         /*
         |--------------------------------------------------------------------------
-        | Webhook URI
+        | Webhook URI / Subdomain
         |--------------------------------------------------------------------------
         |
         | This value is the URI path where OpenAI will send webhook requests to.
         | You may change this path to anything you like. Make sure to update
         | your OpenAI webhook settings to match this URI.
+        | If necessary, you may also specify a custom domain for the webhook route.
         */
         'uri' => env('OPENAI_WEBHOOK_URI', '/openai/webhook'),
+        'domain' => env('OPENAI_WEBHOOK_DOMAIN'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Webhook Middleware
+        |--------------------------------------------------------------------------
+        | Here you may specify the middleware that will be applied to
+        | the OpenAI webhook route.
+        | Note that the signature verification middleware is always applied.
+        */
+        'middleware' => env('OPENAI_WEBHOOK_MIDDLEWARE', 'web'),
 
         /*
         |--------------------------------------------------------------------------

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,9 @@
          displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
 >
+    <php>
+        <env name="APP_KEY" value="base64:dxPp4telCysptcFUIG6Vf2Jm8LXtTixZzsBMPYPZl8I="/>
+    </php>
     <testsuites>
         <testsuite name="Default Test Suite">
             <directory suffix=".php">./tests</directory>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use OpenAI\Laravel\Http\Controllers\WebhookController;
+use OpenAI\Laravel\Http\Middleware\VerifyWebhookSignature;
+
+Route::group(['middleware' => config('openai.webhook.middleware', ['web'])], function () {
+    $webhookUri = config('openai.webhook.uri', '/openai/webhook');
+    assert(is_string($webhookUri));
+
+    Route::post($webhookUri, WebhookController::class)
+        ->name('webhook')
+        ->middleware(VerifyWebhookSignature::class);
+});

--- a/src/Events/WebhookReceived.php
+++ b/src/Events/WebhookReceived.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenAI\Laravel\Events;
+
+use DateTimeInterface;
+use OpenAI\Enums\Webhooks\WebhookEvent;
+
+readonly class WebhookReceived
+{
+    /**
+     * @param  array<array-key, mixed>  $payload
+     */
+    public function __construct(
+        public WebhookEvent $type,
+        public string $id,
+        public DateTimeInterface $timestamp,
+        public array $payload,
+    ) {}
+}

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OpenAI\Laravel\Http\Controllers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use OpenAI\Laravel\Events\WebhookReceived;
+use OpenAI\Laravel\Http\Requests\WebhookRequest;
+
+class WebhookController extends Controller
+{
+    public function __invoke(WebhookRequest $request, Dispatcher $dispatcher): Response
+    {
+        $dispatcher->dispatch(
+            new WebhookReceived(
+                $request->getEventType(),
+                $request->getEventId(),
+                $request->getTimestamp(),
+                $request->getData(),
+            ),
+        );
+
+        return response()->noContent(202);
+    }
+}

--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -1,17 +1,5 @@
 <?php
 
-/**
- * This file is part of openai-php-laravel, a Matchory application.
- *
- * Unauthorized copying of this file, via any medium, is strictly prohibited.
- * Its contents are strictly confidential and proprietary.
- *
- * @copyright 2020–2025 Matchory GmbH · All rights reserved
- * @author    Moritz Friedrich <moritz@matchory.com>
- */
-
-declare(strict_types=1);
-
 namespace OpenAI\Laravel\Http\Middleware;
 
 use Closure;

--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of openai-php-laravel, a Matchory application.
+ *
+ * Unauthorized copying of this file, via any medium, is strictly prohibited.
+ * Its contents are strictly confidential and proprietary.
+ *
+ * @copyright 2020–2025 Matchory GmbH · All rights reserved
+ * @author    Moritz Friedrich <moritz@matchory.com>
+ */
+
+declare(strict_types=1);
+
+namespace OpenAI\Laravel\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use OpenAI\Exceptions\WebhookVerificationException;
+use OpenAI\Webhooks\WebhookSignatureVerifier;
+use RuntimeException;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+readonly class VerifyWebhookSignature
+{
+    public function __construct(
+        private WebhookSignatureVerifier $verifier,
+        private PsrHttpFactory $psrBridge,
+    ) {}
+
+    /**
+     * Handle an incoming request.
+     *
+     * @throws AccessDeniedHttpException
+     * @throws RuntimeException
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $psrRequest = $this->psrBridge->createRequest($request);
+
+        try {
+            $this->verifier->verify($psrRequest);
+        } catch (WebhookVerificationException $exception) {
+            throw new AccessDeniedHttpException(
+                'Invalid webhook signature',
+                $exception,
+            );
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Requests/WebhookRequest.php
+++ b/src/Http/Requests/WebhookRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace OpenAI\Laravel\Http\Requests;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use OpenAI\Enums\Webhooks\WebhookEvent;
+
+class WebhookRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => ['required', 'string', 'starts_with:evt_'],
+            'type' => ['required', 'string', Rule::enum(WebhookEvent::class)],
+            'created_at' => ['required', 'integer', 'min:0'],
+            'data' => ['required', 'array'],
+        ];
+    }
+
+    public function getEventType(): WebhookEvent
+    {
+        $type = $this->input('type');
+        assert(is_string($type));
+
+        return WebhookEvent::from($type);
+    }
+
+    public function getEventId(): string
+    {
+        $id = $this->input('id');
+        assert(is_string($id));
+
+        return $id;
+    }
+
+    public function getTimestamp(): DateTimeInterface
+    {
+        $timestamp = $this->input('created_at');
+        assert(is_int($timestamp));
+
+        return (new DateTimeImmutable)->setTimestamp($timestamp);
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function getData(): array
+    {
+        $data = $this->input('data', []);
+        assert(is_array($data));
+
+        return $data;
+    }
+}

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -11,6 +11,7 @@ test('facades')
         'OpenAI\Contracts\ResponseContract',
         'OpenAI\Laravel\Testing\OpenAIFake',
         'OpenAI\Responses\StreamResponse',
+        'Illuminate\Support\Facades\Route',
     ]);
 
 test('service providers')
@@ -21,6 +22,7 @@ test('service providers')
         'OpenAI\Laravel',
         'OpenAI',
         'Illuminate\Contracts\Support\DeferrableProvider',
+        'Illuminate\Support\Facades\Route',
 
         // helpers...
         'config',

--- a/tests/ServiceProvider.php
+++ b/tests/ServiceProvider.php
@@ -5,6 +5,7 @@ use OpenAI\Client;
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Laravel\Exceptions\ApiKeyIsMissing;
 use OpenAI\Laravel\ServiceProvider;
+use OpenAI\Webhooks\WebhookSignatureVerifier;
 
 it('binds the client on the container', function () {
     $app = app();
@@ -55,8 +56,26 @@ it('provides', function () {
     $provides = (new ServiceProvider($app))->provides();
 
     expect($provides)->toBe([
+        WebhookSignatureVerifier::class,
         Client::class,
         ClientContract::class,
         'openai',
     ]);
+});
+
+it('provides the webhook secret to the signature verifier', function () {
+    $app = app();
+
+    $app->bind('config', fn () => new Repository([
+        'openai' => [
+            'api_key' => 'test',
+            'webhook' => [
+                'secret' => 'whsec_abcd1234',
+            ],
+        ],
+    ]));
+
+    (new ServiceProvider($app))->register();
+
+    expect($app->get(WebhookSignatureVerifier::class))->toBeInstanceOf(WebhookSignatureVerifier::class);
 });

--- a/tests/WebhookTestCase.php
+++ b/tests/WebhookTestCase.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of openai-php-laravel, a Matchory application.
+ *
+ * Unauthorized copying of this file, via any medium, is strictly prohibited.
+ * Its contents are strictly confidential and proprietary.
+ *
+ * @copyright 2020–2025 Matchory GmbH · All rights reserved
+ * @author    Moritz Friedrich <moritz@matchory.com>
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use OpenAI\Laravel\ServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class WebhookTestCase extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ServiceProvider::class,
+        ];
+    }
+}

--- a/tests/WebhookTestCase.php
+++ b/tests/WebhookTestCase.php
@@ -1,17 +1,5 @@
 <?php
 
-/**
- * This file is part of openai-php-laravel, a Matchory application.
- *
- * Unauthorized copying of this file, via any medium, is strictly prohibited.
- * Its contents are strictly confidential and proprietary.
- *
- * @copyright 2020–2025 Matchory GmbH · All rights reserved
- * @author    Moritz Friedrich <moritz@matchory.com>
- */
-
-declare(strict_types=1);
-
 namespace Tests;
 
 use OpenAI\Laravel\ServiceProvider;

--- a/tests/Webhooks.php
+++ b/tests/Webhooks.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Event;
+use JsonException;
+use OpenAI\Enums\Webhooks\WebhookEvent;
+use OpenAI\Exceptions\WebhookVerificationException;
+use OpenAI\Laravel\Events\WebhookReceived;
+use OpenAI\Webhooks\WebhookSignatureVerifier;
+use Orchestra\Testbench\Attributes\WithConfig;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+#[WithConfig('openai.webhook.enabled', true)]
+#[WithConfig('openai.webhook.uri', '/openai/webhook')]
+#[WithConfig('openai.webhook.secret', 'whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw')]
+class Webhooks extends WebhookTestCase
+{
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    #[Test]
+    #[WithConfig('openai.webhook.enabled', false)]
+    public function webhook_route_is_not_registered_when_webhook_is_disabled(): void
+    {
+        $router = $this->app?->get('router');
+        assert($router instanceof Router);
+        $this->assertFalse($router->has('openai.webhook'));
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    #[Test]
+    public function webhook_route_is_registered_when_webhook_is_enabled(): void
+    {
+        $router = $this->app?->get('router');
+        assert($router instanceof Router);
+        $this->assertTrue($router->has('openai.webhook'));
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws JsonException
+     * @throws WebhookVerificationException
+     */
+    #[Test]
+    public function valid_webhook_request_is_accepted(): void
+    {
+        $messageId = 'evt_test_webhook';
+        $timestamp = time();
+        $body = [
+            'id' => 'evt_test_webhook',
+            'type' => WebhookEvent::BatchFailed,
+            'created_at' => $timestamp,
+            'data' => [
+                'id' => 'obj_test_webhook',
+            ],
+        ];
+        $signature = $this->app?->make(WebhookSignatureVerifier::class)->sign(
+            $messageId,
+            $timestamp,
+            json_encode($body, JSON_THROW_ON_ERROR),
+        );
+
+        Event::fake();
+        $this
+            ->postJson('/openai/webhook', $body, [
+                'webhook-id' => $messageId,
+                'webhook-timestamp' => (string) $timestamp,
+                'webhook-signature' => $signature,
+            ])
+            ->assertAccepted();
+        Event::assertDispatched(WebhookReceived::class, static fn (WebhookReceived $event) => (
+            $event->id === $messageId
+            && $event->timestamp->getTimestamp() === $timestamp
+            && $event->type === WebhookEvent::BatchFailed
+            && $event->payload === $body['data']
+        ));
+    }
+
+    #[Test]
+    public function webhook_request_with_invalid_signature_is_rejected(): void
+    {
+        Event::fake();
+        $this
+            ->postJson('/openai/webhook', [
+                'id' => 'evt_test_webhook',
+                'object' => 'event',
+                'type' => 'test.event',
+                'data' => [
+                    'id' => 'obj_test_webhook',
+                ],
+            ], [
+                'webhook-id' => 'evt_test_webhook',
+                'webhook-timestamp' => (string) time(),
+                'webhook-signature' => 'v1,invalid_signature',
+            ])
+            ->assertForbidden();
+        Event::assertNotDispatched(WebhookReceived::class);
+    }
+
+    #[Test]
+    public function webhook_request_without_signature_header_is_rejected(): void
+    {
+        Event::fake();
+        $this
+            ->postJson('/openai/webhook', [
+                'id' => 'evt_test_webhook',
+                'object' => 'event',
+                'type' => 'test.event',
+                'data' => [
+                    'id' => 'obj_test_webhook',
+                ],
+            ], [
+                'webhook-id' => 'evt_test_webhook',
+                'webhook-timestamp' => (string) time(),
+            ])
+            ->assertForbidden();
+        Event::assertNotDispatched(WebhookReceived::class);
+    }
+
+    /**
+     * @throws NotFoundExceptionInterface
+     * @throws ContainerExceptionInterface
+     * @throws JsonException
+     * @throws WebhookVerificationException
+     */
+    #[Test]
+    public function webhook_request_with_missing_id_header_is_rejected(): void
+    {
+        $messageId = 'evt_test_webhook';
+        $timestamp = time();
+        $body = [
+            'id' => 'evt_test_webhook',
+            'type' => WebhookEvent::BatchFailed,
+            'created_at' => $timestamp,
+            'data' => [
+                'id' => 'obj_test_webhook',
+            ],
+        ];
+        $signature = $this->app?->get(WebhookSignatureVerifier::class)->sign(
+            $messageId,
+            $timestamp,
+            json_encode($body, JSON_THROW_ON_ERROR),
+        );
+
+        Event::fake();
+        $this
+            ->postJson('/openai/webhook', $body, [
+                'webhook-timestamp' => (string) $timestamp,
+                'webhook-signature' => $signature,
+            ])
+            ->assertForbidden();
+        Event::assertNotDispatched(WebhookReceived::class);
+    }
+
+    /**
+     * @throws NotFoundExceptionInterface
+     * @throws ContainerExceptionInterface
+     * @throws JsonException
+     * @throws WebhookVerificationException
+     */
+    #[Test]
+    public function webhook_request_with_missing_timestamp_header_is_rejected(): void
+    {
+        $messageId = 'evt_test_webhook';
+        $timestamp = time();
+        $body = [
+            'id' => 'evt_test_webhook',
+            'type' => WebhookEvent::BatchFailed,
+            'created_at' => $timestamp,
+            'data' => [
+                'id' => 'obj_test_webhook',
+            ],
+        ];
+        $signature = $this->app?->get(WebhookSignatureVerifier::class)->sign(
+            $messageId,
+            $timestamp,
+            json_encode($body, JSON_THROW_ON_ERROR),
+        );
+
+        Event::fake();
+        $this
+            ->postJson('/openai/webhook', $body, [
+                'webhook-id' => $messageId,
+                'webhook-signature' => $signature,
+            ])
+            ->assertForbidden();
+        Event::assertNotDispatched(WebhookReceived::class);
+    }
+
+    /**
+     * @throws NotFoundExceptionInterface
+     * @throws ContainerExceptionInterface
+     * @throws JsonException
+     * @throws WebhookVerificationException
+     */
+    #[Test]
+    public function webhook_request_with_old_timestamp_is_rejected(): void
+    {
+        $messageId = 'evt_test_webhook';
+        $timestamp = time();
+        $body = [
+            'id' => 'evt_test_webhook',
+            'type' => WebhookEvent::BatchFailed,
+            'created_at' => $timestamp,
+            'data' => [
+                'id' => 'obj_test_webhook',
+            ],
+        ];
+        $signature = $this->app?->get(WebhookSignatureVerifier::class)->sign(
+            $messageId,
+            $timestamp,
+            json_encode($body, JSON_THROW_ON_ERROR),
+        );
+
+        Event::fake();
+        $this
+            ->postJson('/openai/webhook', $body, [
+                'webhook-id' => $messageId,
+                'webhook-signature' => $signature,
+                'webhook-timestamp' => (string) ($timestamp - 1000),
+            ])
+            ->assertForbidden();
+        Event::assertNotDispatched(WebhookReceived::class);
+    }
+
+    /**
+     * @throws NotFoundExceptionInterface
+     * @throws ContainerExceptionInterface
+     * @throws JsonException
+     * @throws WebhookVerificationException
+     */
+    #[Test]
+    public function webhook_request_with_future_timestamp_is_rejected(): void
+    {
+        $messageId = 'evt_test_webhook';
+        $timestamp = time();
+        $body = [
+            'id' => 'evt_test_webhook',
+            'type' => WebhookEvent::BatchFailed,
+            'created_at' => $timestamp,
+            'data' => [
+                'id' => 'obj_test_webhook',
+            ],
+        ];
+        $signature = $this->app?->get(WebhookSignatureVerifier::class)->sign(
+            $messageId,
+            $timestamp,
+            json_encode($body, JSON_THROW_ON_ERROR),
+        );
+
+        Event::fake();
+        $this
+            ->postJson('/openai/webhook', $body, [
+                'webhook-id' => $messageId,
+                'webhook-signature' => $signature,
+                'webhook-timestamp' => (string) ($timestamp + 1000),
+            ])
+            ->assertForbidden();
+        Event::assertNotDispatched(WebhookReceived::class);
+    }
+
+    /**
+     * @throws NotFoundExceptionInterface
+     * @throws ContainerExceptionInterface
+     * @throws JsonException
+     * @throws WebhookVerificationException
+     */
+    #[Test]
+    public function webhook_request_with_invalid_payload_is_rejected(): void
+    {
+        $messageId = 'evt_test_webhook';
+        $timestamp = time();
+        $body = ['invalid_field' => 'invalid_value'];
+        $signature = $this->app?->get(WebhookSignatureVerifier::class)->sign(
+            $messageId,
+            $timestamp,
+            json_encode($body, JSON_THROW_ON_ERROR),
+        );
+
+        Event::fake();
+        $this
+            ->postJson('/openai/webhook', $body, [
+                'webhook-id' => $messageId,
+                'webhook-timestamp' => $timestamp,
+                'webhook-signature' => $signature,
+            ])
+            ->assertUnprocessable();
+        Event::assertNotDispatched(WebhookReceived::class);
+    }
+}


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature
- [ ] Docs

### Description:

This PR adds webhook handling to the library. This works by adding a webhook route to the application that accepts OpenAI webhook requests and dispatches an event with the request details. Users can listen to this event to implement application-specific handling.

The webhook endpoint can be customised via configuration; if that doesn't suffice, the signature verification middleware can also be used separately.

#### Configuration

The following new configuration parameters are available:

| Parameter                   | Default Value     | Description                                                                         |
|:----------------------------|-------------------|-------------------------------------------------------------------------------------|
| `openai.webhook.enabled`    | `false`           | Whether webhook handling is enabled. If disabled, the route will not be registered. |
| `openai.webhook.secret`     | —                 | The signing secret obtained from OpenAI used to verify the webhook signature.       |
| `openai.webhook.uri`        | `/openai/webhook` | URI of the webhook endpoint.                                                        |
| `openai.webhook.domain`     | —                 | Optional domain for the route registration.                                         |
| `openai.webhook.middleware` | 'web'             | Middleware(s) to use for the route registration.                                    |

### Related:

This will solve #186.