### PR TITLE
Reject empty OpenAI API keys

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -28,7 +28,11 @@ final class ServiceProvider extends BaseServiceProvider implements DeferrablePro
             $project = config('openai.project');
             $baseUri = config('openai.base_uri');
 
-            if (! is_string($apiKey) || ($organization !== null && ! is_string($organization))) {
+            if (is_string($apiKey)) {
+                $apiKey = trim($apiKey);
+            }
+
+            if ((! is_string($apiKey) || $apiKey === '') || ($organization !== null && ! is_string($organization))) {
                 throw ApiKeyIsMissing::create();
             }
 

--- a/tests/ServiceProvider.php
+++ b/tests/ServiceProvider.php
@@ -49,6 +49,26 @@ it('requires an api key', function () {
     'The OpenAI API Key is missing. Please publish the [openai.php] configuration file and set the [api_key].',
 );
 
+it('requires a non-empty api key', function (string $apiKey) {
+    $app = app();
+
+    $app->bind('config', fn () => new Repository([
+        'openai' => [
+            'api_key' => $apiKey,
+        ],
+    ]));
+
+    (new ServiceProvider($app))->register();
+
+    $app->get(Client::class);
+})->with([
+    'empty string' => '',
+    'blank string' => '   ',
+])->throws(
+    ApiKeyIsMissing::class,
+    'The OpenAI API Key is missing. Please publish the [openai.php] configuration file and set the [api_key].',
+);
+
 it('provides', function () {
     $app = app();
 


### PR DESCRIPTION
  ### What:

  - [x] Bug Fix
  - [ ] New Feature
  - [ ] Docs

  ### Description:

This PR treats empty and whitespace-only OpenAI API keys as missing configuration.

Previously, `config('openai.api_key')` only had to be a string. That allowed values like `''` or `'   '` to pass validation and build a client, causing the failure to happen later as an API authentication error instead of the package's `ApiKeyIsMissing` exception.

  ### Related:

  N/A
